### PR TITLE
Update Meta Pixel ID to new tracking account

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Keep both pages in sync when updating contact info.
 | Scripts | Inline `<script>` blocks inside `index.html` — vanilla ES6 JavaScript |
 | Fonts | Google Fonts: **Playfair Display** (headings) + **DM Sans** (body) |
 | Form backend | Google Apps Script macro (POST endpoint, stores leads in Google Sheets) |
-| Analytics | Google Analytics 4 (`G-4L3ZXGG3JZ`) + Meta Pixel (`1792763298349619`) |
+| Analytics | Google Analytics 4 (`G-4L3ZXGG3JZ`) + Meta Pixel (`2075120536666616`) |
 | Hosting | Static file — served as-is from any web server |
 | CI/CD | GitHub Actions with `anthropics/claude-code-action@beta` |
 
@@ -326,7 +326,7 @@ The `.social-proof-banner` contains three `.proof-stat` blocks. Edit the `.stat-
 
 | Service | ID |
 |---------|----|
-| Meta Pixel (Facebook) | `1792763298349619` |
+| Meta Pixel (Facebook) | `2075120536666616` |
 | Google Analytics 4 | `G-4L3ZXGG3JZ` |
 
 Both scripts load asynchronously in `<head>`. The Lead event fires after successful form submission. Do not remove or break these tracking integrations.

--- a/index.html
+++ b/index.html
@@ -61,11 +61,11 @@
     t.src=v;s=b.getElementsByTagName(e)[0];
     s.parentNode.insertBefore(t,s)}(window, document,'script',
     'https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', '1792763298349619');
+    fbq('init', '2075120536666616');
     fbq('track', 'PageView');
     </script>
     <noscript><img height="1" width="1" style="display:none"
-    src="https://www.facebook.com/tr?id=1792763298349619&ev=PageView&noscript=1"
+    src="https://www.facebook.com/tr?id=2075120536666616&ev=PageView&noscript=1"
     /></noscript>
     <!-- End Meta Pixel Code -->
     


### PR DESCRIPTION
## Summary
Updates the Meta Pixel tracking ID across the codebase to use a new Facebook/Meta business account for analytics and conversion tracking.

## Changes
- **Meta Pixel ID**: Updated from `1792763298349619` to `2075120536666616`
  - Updated in `index.html` Meta Pixel initialization script (2 occurrences)
  - Updated in `CLAUDE.md` documentation (2 occurrences)

## Details
The Meta Pixel tracking code in the `<head>` section of `index.html` has been updated to initialize with the new pixel ID. This includes:
- The `fbq('init', ...)` call that initializes the pixel
- The noscript fallback image tracking URL

Documentation in `CLAUDE.md` has been kept in sync to reflect the new tracking ID in both the tech stack overview and the analytics configuration reference section.

All other tracking integrations (Google Analytics 4) remain unchanged.

https://claude.ai/code/session_01BFwUiw4YyKjkprTKiK7VKk